### PR TITLE
add: 予約変更機能のプロトタイプを実装しました

### DIFF
--- a/frontend/src/components/ConfirmationContentDisplay.vue
+++ b/frontend/src/components/ConfirmationContentDisplay.vue
@@ -1,55 +1,45 @@
 <script setup lang="ts">
 import { useFormStore } from '@/stores/formStore'
+import { storeToRefs } from 'pinia'
 
-const { formData } = useFormStore()
-const {
-  name,
-  gender,
-  birthday,
-  prefecture,
-  tel,
-  email,
-  is_accompanied,
-  visit_day,
-  visit_time,
-} = formData
+const { entryData } = storeToRefs(useFormStore())
 </script>
 
 <template>
   <div>
     <p>お名前</p>
-    <p>{{ name }}</p>
+    <p>{{ entryData.name }}</p>
   </div>
   <div>
     <p>性別</p>
-    <p>{{ gender }}</p>
+    <p>{{ entryData.gender }}</p>
   </div>
   <div>
     <p>生年月日</p>
-    <p>{{ birthday }}</p>
+    <p>{{ entryData.birthday }}</p>
   </div>
   <div>
     <p>都道府県</p>
-    <p>{{ prefecture }}</p>
+    <p>{{ entryData.prefecture }}</p>
   </div>
   <div>
     <p>電話番号</p>
-    <p>{{ tel }}</p>
+    <p>{{ entryData.tel }}</p>
   </div>
   <div>
     <p>メールアドレス</p>
-    <p>{{ email }}</p>
+    <p>{{ entryData.email }}</p>
   </div>
   <div>
     <p>同伴者</p>
-    <p>{{ is_accompanied }}</p>
+    <p>{{ entryData.isAccompanied }}</p>
   </div>
   <div>
     <p>来場日</p>
-    <p>{{ visit_day }}</p>
+    <p>{{ entryData.visitDay }}</p>
   </div>
   <div>
     <p>来場時間</p>
-    <p>{{ visit_time }}</p>
+    <p>{{ entryData.visitTime }}</p>
   </div>
 </template>

--- a/frontend/src/components/FormComponents.vue
+++ b/frontend/src/components/FormComponents.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import type { Entry } from '@/types/entry'
-import { ref } from 'vue'
 import { useFormStore } from '@/stores/formStore'
 
 import GenderField from '@/components/fields/Gender/GenderField.vue'
@@ -17,28 +15,38 @@ import RouterLinkButton from './atoms/Button/RouterLinkButton.vue'
 import NameField from './fields/Name/NameField.vue'
 
 const formStore = useFormStore()
-const pushToFormData = formStore.pushToFormData
-const formData = formStore.formData
+const saveEntryData = formStore.saveEntryData
+const entryData = {
+  name: '',
+  gender: '',
+  birthday: '',
+  prefecture: '',
+  tel: '',
+  email: '',
+  isAccompanied: '',
+  visitDay: '',
+  visitTime: '',
+}
 </script>
 
 <template>
-  <NameField v-model="formData.name" />
-  <GenderField v-model="formData.gender" />
-  <BirthdayField v-model="formData.birthday" />
-  <PrefectureField v-model="formData.prefecture" />
-  <PhoneField v-model="formData.tel" />
-  <EmailField v-model="formData.email" />
+  <NameField v-model="entryData.name" />
+  <GenderField v-model="entryData.gender" />
+  <BirthdayField v-model="entryData.birthday" />
+  <PrefectureField v-model="entryData.prefecture" />
+  <PhoneField v-model="entryData.tel" />
+  <EmailField v-model="entryData.email" />
 
   <hr />
 
-  <CompanionField v-model="formData.is_accompanied" />
-  <CalendarDateField v-model="formData.visit_day" />
-  <CalendarTimeField v-model="formData.visit_time" />
+  <CompanionField v-model="entryData.isAccompanied" />
+  <CalendarDateField v-model="entryData.visitDay" />
+  <CalendarTimeField v-model="entryData.visitTime" />
 
   <PrivacyField />
   <TermsField />
 
-  <RouterLinkButton to="/entry/confirm" @click-event="pushToFormData(formData)">
+  <RouterLinkButton to="/entry/confirm" @click-event="saveEntryData(entryData)">
     入力内容確認画面へ
   </RouterLinkButton>
   <RouterLinkButton to=""> 戻る </RouterLinkButton>

--- a/frontend/src/components/fields/Email/EmailField.vue
+++ b/frontend/src/components/fields/Email/EmailField.vue
@@ -4,6 +4,6 @@ const model = defineModel<string>()
 </script>
 
 <template>
-  <TextInput :label="'メールアドレス'" v-model="model" />
+  <TextInput label="メールアドレス" v-model="model" />
   <p>※本イベントに関して、ご連絡させていただく可能性がございます。</p>
 </template>

--- a/frontend/src/components/fields/Gender/GenderField.vue
+++ b/frontend/src/components/fields/Gender/GenderField.vue
@@ -7,8 +7,8 @@ const model = defineModel<string>()
 <template>
   <fieldset>
     <legend>性別</legend>
-    <RadioButton name="gender" :value="'男性'" v-model="model"/>
-    <RadioButton name="gender" :value="'女性'" v-model="model"/>
-    <RadioButton name="gender" :value="'その他'" v-model="model"/>
+    <RadioButton name="gender" value="男性" v-model="model"/>
+    <RadioButton name="gender" value="女性" v-model="model"/>
+    <RadioButton name="gender" value="その他" v-model="model"/>
   </fieldset>
 </template>

--- a/frontend/src/components/fields/Name/NameField.vue
+++ b/frontend/src/components/fields/Name/NameField.vue
@@ -5,5 +5,5 @@ const model = defineModel<string>()
 </script>
 
 <template>
-  <TextInput :label="'お名前'" v-model="model" />
+  <TextInput label="お名前" v-model="model" />
 </template>

--- a/frontend/src/components/fields/Phone/PhoneField.vue
+++ b/frontend/src/components/fields/Phone/PhoneField.vue
@@ -4,5 +4,5 @@ const model = defineModel<string>()
 </script>
 
 <template>
-  <TextInput :label="'電話番号'" v-model="model" />
+  <TextInput label="電話番号" v-model="model" />
 </template>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,7 +1,11 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import EntryForm from '@/views/Entry/EntryForm.vue'
+import EntryChangeForm from '@/views/EntryChange/EntryChangeForm.vue'
 import EntryFormConfirmation from '@/views/Entry/EntryFormConfirmation.vue'
 import EntryFormCompletion from '@/views/Entry/EntryFormCompletion.vue'
+import EntryConfirmation from '@/views/EntryChange/EntryConfirmation.vue'
+import EntryChangeFormConfirmation from '@/views/EntryChange/EntryChangeFormConfirmation.vue'
+import EntryChangeFormCompletion from '@/views/EntryChange/EntryChangeFormCompletion.vue'
 
 const routes = [
   {
@@ -18,6 +22,26 @@ const routes = [
     path: '/entry/complete',
     name: 'entry-form-completion-view',
     component: EntryFormCompletion,
+  },
+  {
+    path: '/confirm',
+    name: 'entry-confirmation-view',
+    component: EntryConfirmation,
+  },
+  {
+    path: '/entrychange',
+    name: 'entry-change-form-view',
+    component: EntryChangeForm,
+  },
+  {
+    path: '/entrychange/confirm',
+    name: 'entry-change-form-confirmation-view',
+    component: EntryChangeFormConfirmation,
+  },
+  {
+    path: '/entrychange/complete',
+    name: 'entry-change-form-completion-view',
+    component: EntryChangeFormCompletion,
   },
 ]
 

--- a/frontend/src/stores/formStore.ts
+++ b/frontend/src/stores/formStore.ts
@@ -3,29 +3,36 @@ import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
 export const useFormStore = defineStore('form-store', () => {
-  const formData = ref<Entry>({
+  const entryData = ref<Entry>({
     name: '',
     gender: '',
     birthday: '',
     prefecture: '',
     tel: '',
     email: '',
-    is_accompanied: '',
-    visit_day: '',
-    visit_time: '',
+    isAccompanied: '',
+    visitDay: '',
+    visitTime: '',
   })
 
-  function pushToFormData(submittedData: Entry) {
-    formData.value = submittedData
-    console.log(formData.value)
-  }
-
-  const entryData = ref<Entry[]>([])
-
-  function pushToEntryData() {
-    entryData.value.push(formData.value)
+  function saveEntryData(submittedData: Entry) {
+    entryData.value = submittedData
     console.log(entryData.value)
   }
 
-  return { formData, pushToFormData, entryData, pushToEntryData }
+  function getEntryData() {
+    entryData.value = {
+      name: '山田太郎',
+      gender: '男性',
+      birthday: '1994年4月23日',
+      prefecture: '東京都',
+      tel: '09012345678',
+      email: 'xxxxxx@xxxxxx.co.jp',
+      isAccompanied: 'あり',
+      visitDay: '2025年1月1日(水)',
+      visitTime: '14:00',
+    }
+  }
+
+  return { entryData, saveEntryData, getEntryData }
 })

--- a/frontend/src/types/entry.ts
+++ b/frontend/src/types/entry.ts
@@ -5,7 +5,7 @@ export interface Entry {
   prefecture: string
   tel: string
   email: string
-  is_accompanied: string
-  visit_day: string
-  visit_time: string
+  isAccompanied: string
+  visitDay: string
+  visitTime: string
 }

--- a/frontend/src/views/Entry/EntryForm.vue
+++ b/frontend/src/views/Entry/EntryForm.vue
@@ -5,6 +5,6 @@ import FormComponents from '@/components/FormComponents.vue'
 </script>
 
 <template>
-  <PageTitle :title="'ご予約フォーム'" :message="'お客様情報を入力'" />
+  <PageTitle title="ご予約フォーム" message="お客様情報を入力" />
   <FormComponents />
 </template>

--- a/frontend/src/views/Entry/EntryFormCompletion.vue
+++ b/frontend/src/views/Entry/EntryFormCompletion.vue
@@ -5,7 +5,7 @@ import PageTitle from '@/components/PageTitle.vue'
 </script>
 
 <template>
-  <PageTitle :title="'予約完了'" :message="''" />
+  <PageTitle title="予約完了" message="" />
   <p>ご予約が完了しました。LINEのトークルームにご予約情報をお送りしておりますのでご確認ください。</p>
   <RouterLinkButton to=""> 閉じる </RouterLinkButton>
 </template>

--- a/frontend/src/views/Entry/EntryFormConfirmation.vue
+++ b/frontend/src/views/Entry/EntryFormConfirmation.vue
@@ -6,7 +6,7 @@ import RouterLinkButton from '@/components/atoms/Button/RouterLinkButton.vue';
 </script>
 
 <template>
-  <PageTitle :title="'入力内容確認画面'" :message="'以下の内容で予約しますか？'" />
+  <PageTitle title="入力内容確認画面" message="以下の内容で予約しますか？" />
   <ConfirmationContentDisplay />
 
   <RouterLinkButton to="/entry/complete">

--- a/frontend/src/views/EntryChange/EntryChangeForm.vue
+++ b/frontend/src/views/EntryChange/EntryChangeForm.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import PageTitle from '@/components/PageTitle.vue'
+import CompanionField from '@/components/fields/Companion/CompanionField.vue'
+import CalendarDateField from '@/components/fields/Calendar/CalendarDateField.vue'
+import CalendarTimeField from '@/components/fields/Calendar/CalendarTimeField.vue'
+import RouterLinkButton from '@/components/atoms/Button/RouterLinkButton.vue'
+import { useFormStore } from '@/stores/formStore'
+// import { ref } from 'vue'
+// import { storeToRefs } from 'pinia'
+
+const { entryData, saveEntryData } = useFormStore()
+
+// const isAccompanied = ref<string>('')
+// const visitDay = ref<string>('')
+// const visitTime = ref<string>('')
+const changedData = {
+  name: entryData.name,
+  gender: entryData.gender,
+  birthday: entryData.birthday,
+  prefecture: entryData.prefecture,
+  tel: entryData.tel,
+  email: entryData.email,
+  isAccompanied: entryData.isAccompanied,
+  visitDay: entryData.visitDay,
+  visitTime: entryData.visitTime,
+}
+</script>
+
+<template>
+  <PageTitle :title="'日程変更'" :message="'入力内容を変更'" />
+
+  <CompanionField v-model="changedData.isAccompanied" />
+  <CalendarDateField v-model="changedData.visitDay" />
+  <CalendarTimeField v-model="changedData.visitTime" />
+
+  <RouterLinkButton to="/entrychange/confirm" @click-event="saveEntryData(changedData)">
+    入力内容確認画面へ
+  </RouterLinkButton>
+  <RouterLinkButton to="/confirm"> 戻る </RouterLinkButton>
+</template>

--- a/frontend/src/views/EntryChange/EntryChangeForm.vue
+++ b/frontend/src/views/EntryChange/EntryChangeForm.vue
@@ -27,7 +27,7 @@ const changedData = {
 </script>
 
 <template>
-  <PageTitle :title="'日程変更'" :message="'入力内容を変更'" />
+  <PageTitle title="日程変更" message="入力内容を変更" />
 
   <CompanionField v-model="changedData.isAccompanied" />
   <CalendarDateField v-model="changedData.visitDay" />

--- a/frontend/src/views/EntryChange/EntryChangeFormCompletion.vue
+++ b/frontend/src/views/EntryChange/EntryChangeFormCompletion.vue
@@ -5,7 +5,7 @@ import PageTitle from '@/components/PageTitle.vue'
 </script>
 
 <template>
-  <PageTitle :title="'予約完了'" :message="''" />
+  <PageTitle title="予約完了" message="" />
   <p>ご予約が完了しました。LINEのトークルームにご予約情報をお送りしておりますのでご確認ください。</p>
   <RouterLinkButton to=""> 閉じる </RouterLinkButton>
 </template>

--- a/frontend/src/views/EntryChange/EntryChangeFormCompletion.vue
+++ b/frontend/src/views/EntryChange/EntryChangeFormCompletion.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import RouterLinkButton from '@/components/atoms/Button/RouterLinkButton.vue';
+import PageTitle from '@/components/PageTitle.vue'
+
+</script>
+
+<template>
+  <PageTitle :title="'予約完了'" :message="''" />
+  <p>ご予約が完了しました。LINEのトークルームにご予約情報をお送りしておりますのでご確認ください。</p>
+  <RouterLinkButton to=""> 閉じる </RouterLinkButton>
+</template>

--- a/frontend/src/views/EntryChange/EntryChangeFormConfirmation.vue
+++ b/frontend/src/views/EntryChange/EntryChangeFormConfirmation.vue
@@ -6,11 +6,11 @@ import RouterLinkButton from '@/components/atoms/Button/RouterLinkButton.vue';
 </script>
 
 <template>
-  <PageTitle :title="'入力内容確認画面'" :message="'以下の内容で予約しますか？'" />
+  <PageTitle :title="'入力内容確認画面'" :message="'以下の内容で変更しますか？'" />
   <ConfirmationContentDisplay />
 
-  <RouterLinkButton to="/entry/complete">
-    予約する
+  <RouterLinkButton to="/entrychange/complete">
+    予約内容を変更する
   </RouterLinkButton>
-  <RouterLinkButton to="/entry"> 内容を修正する </RouterLinkButton>
+  <RouterLinkButton to="/entrychange"> 内容を修正する </RouterLinkButton>
 </template>

--- a/frontend/src/views/EntryChange/EntryChangeFormConfirmation.vue
+++ b/frontend/src/views/EntryChange/EntryChangeFormConfirmation.vue
@@ -6,7 +6,7 @@ import RouterLinkButton from '@/components/atoms/Button/RouterLinkButton.vue';
 </script>
 
 <template>
-  <PageTitle :title="'入力内容確認画面'" :message="'以下の内容で変更しますか？'" />
+  <PageTitle title="入力内容確認画面" message="以下の内容で変更しますか？" />
   <ConfirmationContentDisplay />
 
   <RouterLinkButton to="/entrychange/complete">

--- a/frontend/src/views/EntryChange/EntryConfirmation.vue
+++ b/frontend/src/views/EntryChange/EntryConfirmation.vue
@@ -1,16 +1,21 @@
 <script setup lang="ts">
-import ConfirmationContentDisplay from '@/components/ConfirmationContentDisplay.vue';
 import PageTitle from '@/components/PageTitle.vue'
-import RouterLinkButton from '@/components/atoms/Button/RouterLinkButton.vue';
+import RouterLinkButton from '@/components/atoms/Button/RouterLinkButton.vue'
+import ConfirmationContentDisplay from '@/components/ConfirmationContentDisplay.vue'
+import { onMounted } from 'vue'
+import { useFormStore } from '@/stores/formStore'
 
+const { getEntryData } = useFormStore()
+
+onMounted(() => {
+  getEntryData()
+})
 </script>
 
 <template>
   <PageTitle :title="'予約内容の確認'" :message="''" />
   <ConfirmationContentDisplay />
 
-  <RouterLinkButton to="/entry/complete">
-    予約する
-  </RouterLinkButton>
-  <RouterLinkButton to="/entry"> 内容を修正する </RouterLinkButton>
+  <RouterLinkButton to="/entrychange"> 予約内容を変更する </RouterLinkButton>
+  <RouterLinkButton to=""> 閉じる </RouterLinkButton>
 </template>

--- a/frontend/src/views/EntryChange/EntryConfirmation.vue
+++ b/frontend/src/views/EntryChange/EntryConfirmation.vue
@@ -13,7 +13,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <PageTitle :title="'予約内容の確認'" :message="''" />
+  <PageTitle title="予約内容の確認" message="" />
   <ConfirmationContentDisplay />
 
   <RouterLinkButton to="/entrychange"> 予約内容を変更する </RouterLinkButton>


### PR DESCRIPTION
- 既存の予約確認画面
  - EntryConfirmationのonMountedにて、getEntryDataでstoreのentryDataに擬似的な予約データを代入しました。entryDataをレンダリングするコンポーネントである、ConfirmationContentDisplayによって、既存の予約が表示されます。
- 予約変更フォームから予約変更確認画面の遷移
  - EntryChangeFormでは、changedData変数に既存の予約情報を格納してきて、変更フォームに入力欄があるプロパティのみ、v-modelで同期しています。クリックイベントに設定されたsaveEntryDataによって、changedDataがentryDataに代入され、同じくConfirmationContentDisplayによって変更された予約が表示されます。


https://github.com/user-attachments/assets/de303db0-5ca3-4986-bad1-30098d557c4a

