### PR TITLE
add/introduce-get-api-into-vue

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "wecall",
       "version": "0.0.0",
       "dependencies": {
+        "date-fns": "^4.1.0",
         "pinia": "^2.3.0",
         "vue": "^3.5.13",
         "vue-router": "^4.5.0"
@@ -2504,6 +2505,16 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/de-indent": {
       "version": "1.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
+    "date-fns": "^4.1.0",
     "pinia": "^2.3.0",
     "vue": "^3.5.13",
     "vue-router": "^4.5.0"

--- a/frontend/src/components/ConfirmationContentDisplay.vue
+++ b/frontend/src/components/ConfirmationContentDisplay.vue
@@ -13,10 +13,11 @@ const { entryData } = storeToRefs(useEntryStore())
         entryData.familyName +
         ' ' +
         entryData.personalName +
-        ' ' +
+        '（' +
         entryData.familyNameKana +
         ' ' +
-        entryData.personalNameKana
+        entryData.personalNameKana +
+        '）'
       }}
     </p>
   </div>

--- a/frontend/src/composables/useEntriesAPI.ts
+++ b/frontend/src/composables/useEntriesAPI.ts
@@ -1,6 +1,23 @@
-import type { Entry } from '@/types/entry'
+import type { Entry, EntryReturnedByAPI } from '@/types/entry'
 
 export function useEntriesAPI() {
+  class EntryGetFailure extends Error {
+    constructor() {
+      super()
+    }
+  }
+
+  const useGetEntryAPI = async (id: number): Promise<EntryReturnedByAPI> => {
+    const response = await fetch(`http://localhost:3000/entries/${id}`, {
+      method: 'GET',
+    })
+
+    if (!response.ok) {
+      throw new EntryGetFailure()
+    }
+
+    return (await response.json()) as EntryReturnedByAPI
+  }
   class EntryAddFailure extends Error {
     constructor() {
       super()
@@ -8,7 +25,7 @@ export function useEntriesAPI() {
   }
 
   const useAddEntryAPI = async (entry: Entry) => {
-    console.log(JSON.stringify(entry))
+    // console.log(JSON.stringify(entry))
     const response = await fetch('http://localhost:3000/entries', {
       method: 'POST',
       headers: {
@@ -18,12 +35,13 @@ export function useEntriesAPI() {
     })
 
     if (!response.ok) {
-      console.log(response)
+      // console.log(response)
       throw new EntryAddFailure()
     }
   }
 
   return {
+    useGetEntryAPI,
     useAddEntryAPI,
   }
 }

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -31,27 +31,27 @@ const routes = [
     component: EntryConfirmation,
   },
   {
-    path: '/entrychange',
+    path: '/entry/change',
     name: 'entry-change-form-view',
     component: EntryChangeForm,
   },
   {
-    path: '/entrychange/confirm',
+    path: '/entry/change/confirm',
     name: 'entry-change-form-confirmation-view',
     component: EntryChangeFormConfirmation,
   },
   {
-    path: '/entrychange/complete',
+    path: '/entry/change/complete',
     name: 'entry-change-form-completion-view',
     component: EntryChangeFormCompletion,
   },
   {
-    path: '/entrycancel/confirm',
+    path: '/entry/cancel/confirm',
     name: 'entry-cancel-confirmation-view',
     component: EntryCancelConfirmation,
   },
   {
-    path: '/entrycancel/complete',
+    path: '/entry/cancel/complete',
     name: 'entry-cancel-completion-view',
     component: EntryCancelCompletion,
   },

--- a/frontend/src/stores/entryStore.ts
+++ b/frontend/src/stores/entryStore.ts
@@ -1,9 +1,9 @@
-import type { Entry } from '@/types/entry'
+import type { Entry, EntryReturnedByAPI } from '@/types/entry'
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { useEntriesAPI } from '@/composables/useEntriesAPI'
 
-const { useAddEntryAPI: useAddEntryAPI } = useEntriesAPI()
+const { useAddEntryAPI: useAddEntryAPI, useGetEntryAPI: useGetEntryAPI } = useEntriesAPI()
 
 export const useEntryStore = defineStore('entry-store', () => {
   const entryData = ref<Entry>({
@@ -23,8 +23,17 @@ export const useEntryStore = defineStore('entry-store', () => {
 
   const errorMsg = ref<string>()
 
+  async function getEntry(id: number): Promise<EntryReturnedByAPI | null> {
+    try {
+      return await useGetEntryAPI(id)
+    } catch (error) {
+      if (error) errorMsg.value = '該当データを取得できませんでした'
+      return null
+    }
+  }
+
   async function registerEntry(submittedEntry: Entry) {
-    console.log(submittedEntry)
+    // console.log(submittedEntry)
     try {
       await useAddEntryAPI(submittedEntry)
     } catch (error) {
@@ -51,19 +60,5 @@ export const useEntryStore = defineStore('entry-store', () => {
     }
   }
 
-  function getEntryData() {
-    entryData.value = {
-      name: '山田太郎',
-      gender: '男性',
-      birthday: '1994年4月23日',
-      prefecture: '東京都',
-      tel: '09012345678',
-      email: 'xxxxxx@xxxxxx.co.jp',
-      isAccompanied: 'あり',
-      visitDay: '2025年1月1日(水)',
-      visitTime: '14:00',
-    }
-  }
-
-  return { entryData, registerEntry, saveEntryToStore, deleteEntryData, getEntryData }
+  return { entryData, registerEntry, saveEntryToStore, deleteEntryData, getEntry }
 })

--- a/frontend/src/views/EntryCancel/EntryCancelConfirmation.vue
+++ b/frontend/src/views/EntryCancel/EntryCancelConfirmation.vue
@@ -4,11 +4,20 @@ import RouterLinkButton from '@/components/atoms/Button/RouterLinkButton.vue'
 import ConfirmationContentDisplay from '@/components/ConfirmationContentDisplay.vue'
 import { onMounted } from 'vue'
 import { useEntryStore } from '@/stores/entryStore'
+import { format } from 'date-fns'
+import { ja } from 'date-fns/locale'
 
-const { getEntryData, deleteEntryData } = useEntryStore()
+const { getEntry, saveEntryToStore, deleteEntryData } = useEntryStore()
 
-onMounted(() => {
-  getEntryData()
+onMounted(async () => {
+  const registeredEntry = await getEntry(12)
+  const formattedEntry = {
+    ...registeredEntry,
+    birthday: format(registeredEntry.birthday, 'yyyy年M月d日'),
+    isAccompanied: registeredEntry.isAccompanied ? 'あり' : 'なし',
+    visitDay: format(registeredEntry.visitDay, 'yyyy年M月d日(EEE)', { locale: ja }),
+  }
+  saveEntryToStore(formattedEntry)
 })
 </script>
 
@@ -16,7 +25,7 @@ onMounted(() => {
   <PageTitle title="予約キャンセル" message="以下の内容をキャンセルしますか？" />
   <ConfirmationContentDisplay />
 
-  <RouterLinkButton to="/entrycancel/complete" @click-event="deleteEntryData()">
+  <RouterLinkButton to="/entry/cancel/complete" @click-event="deleteEntryData()">
     予約をキャンセルする
   </RouterLinkButton>
   <RouterLinkButton to=""> 閉じる </RouterLinkButton>

--- a/frontend/src/views/EntryChange/EntryChangeForm.vue
+++ b/frontend/src/views/EntryChange/EntryChangeForm.vue
@@ -33,7 +33,7 @@ const changedData = {
   <CalendarDateField v-model="changedData.visitDay" />
   <CalendarTimeField v-model="changedData.visitTime" />
 
-  <RouterLinkButton to="/entrychange/confirm" @click-event="saveEntryData(changedData)">
+  <RouterLinkButton to="/entry/change/confirm" @click-event="saveEntryData(changedData)">
     入力内容確認画面へ
   </RouterLinkButton>
   <RouterLinkButton to="/confirm"> 戻る </RouterLinkButton>

--- a/frontend/src/views/EntryChange/EntryChangeFormConfirmation.vue
+++ b/frontend/src/views/EntryChange/EntryChangeFormConfirmation.vue
@@ -9,8 +9,8 @@ import RouterLinkButton from '@/components/atoms/Button/RouterLinkButton.vue';
   <PageTitle title="入力内容確認画面" message="以下の内容で変更しますか？" />
   <ConfirmationContentDisplay />
 
-  <RouterLinkButton to="/entrychange/complete">
+  <RouterLinkButton to="/entry/change/complete">
     予約内容を変更する
   </RouterLinkButton>
-  <RouterLinkButton to="/entrychange"> 内容を修正する </RouterLinkButton>
+  <RouterLinkButton to="/entry/change"> 内容を修正する </RouterLinkButton>
 </template>

--- a/frontend/src/views/EntryChange/EntryConfirmation.vue
+++ b/frontend/src/views/EntryChange/EntryConfirmation.vue
@@ -4,11 +4,20 @@ import RouterLinkButton from '@/components/atoms/Button/RouterLinkButton.vue'
 import ConfirmationContentDisplay from '@/components/ConfirmationContentDisplay.vue'
 import { onMounted } from 'vue'
 import { useEntryStore } from '@/stores/entryStore'
+import { format } from 'date-fns'
+import { ja } from 'date-fns/locale'
 
-const { getEntryData } = useEntryStore()
+const { getEntry, saveEntryToStore } = useEntryStore()
 
-onMounted(() => {
-  getEntryData()
+onMounted(async () => {
+  const registeredEntry = await getEntry(12)
+  const formattedEntry = {
+    ...registeredEntry,
+    birthday: format(registeredEntry.birthday, 'yyyy年M月d日'),
+    isAccompanied: registeredEntry.isAccompanied ? 'あり' : 'なし',
+    visitDay: format(registeredEntry.visitDay, 'yyyy年M月d日(EEE)', { locale: ja }),
+  }
+  saveEntryToStore(formattedEntry)
 })
 </script>
 
@@ -16,6 +25,6 @@ onMounted(() => {
   <PageTitle title="予約内容の確認" message="" />
   <ConfirmationContentDisplay />
 
-  <RouterLinkButton to="/entrychange"> 予約内容を変更する </RouterLinkButton>
+  <RouterLinkButton to="/entry/change"> 予約内容を変更する </RouterLinkButton>
   <RouterLinkButton to=""> 閉じる </RouterLinkButton>
 </template>


### PR DESCRIPTION
## 概要
- 予約情報を1件取得するAPIをVueに導入

## 背景/経緯
- 予約確認画面表示の際、DBから予約情報を取得するため

## 参考
- 予約確認画面(EntryConfirm.vue)
![スクリーンショット 2025-02-03 11 59 26](https://github.com/user-attachments/assets/f8804509-1a03-4282-b8b7-0b126b164d4a)
