### PR TITLE
add/introduce-update-api-into-vue

### DIFF
--- a/frontend/src/composables/useEntriesAPI.ts
+++ b/frontend/src/composables/useEntriesAPI.ts
@@ -1,4 +1,4 @@
-import type { Entry, EntryReturnedByAPI } from '@/types/entry'
+import type { Entry, EntryReturnedByAPI, updatedEntryProperties } from '@/types/entry'
 
 export function useEntriesAPI() {
   class EntryGetFailure extends Error {
@@ -40,8 +40,29 @@ export function useEntriesAPI() {
     }
   }
 
+  class EntryUpdateFailure extends Error {
+    constructor() {
+      super()
+    }
+  }
+
+  const useUpdateEntryAPI = async (id: number, properties: updatedEntryProperties) => {
+    const response = await fetch(`http://localhost:3000/entries/${id}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(properties),
+    })
+
+    if (!response.ok) {
+      throw new EntryUpdateFailure()
+    }
+  }
+
   return {
     useGetEntryAPI,
     useAddEntryAPI,
+    useUpdateEntryAPI,
   }
 }

--- a/frontend/src/stores/entryStore.ts
+++ b/frontend/src/stores/entryStore.ts
@@ -1,9 +1,13 @@
-import type { Entry, EntryReturnedByAPI } from '@/types/entry'
+import type { Entry, EntryReturnedByAPI, updatedEntryProperties } from '@/types/entry'
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { useEntriesAPI } from '@/composables/useEntriesAPI'
 
-const { useAddEntryAPI: useAddEntryAPI, useGetEntryAPI: useGetEntryAPI } = useEntriesAPI()
+const {
+  useGetEntryAPI: useGetEntryAPI,
+  useAddEntryAPI: useAddEntryAPI,
+  useUpdateEntryAPI: useUpdateEntryAPI,
+} = useEntriesAPI()
 
 export const useEntryStore = defineStore('entry-store', () => {
   const entryData = ref<Entry>({
@@ -42,6 +46,16 @@ export const useEntryStore = defineStore('entry-store', () => {
     }
   }
 
+  async function changeEntry(id: number, changedProperties: updatedEntryProperties) {
+    try {
+      if ((await useGetEntryAPI(id)) !== null) {
+        await useUpdateEntryAPI(id, changedProperties)
+      }
+    } catch (error) {
+      if (error) errorMsg.value = 'サーバーエラーにより予約できませんでした'
+    }
+  }
+
   function saveEntryToStore(entry: Entry) {
     entryData.value = entry
   }
@@ -60,5 +74,5 @@ export const useEntryStore = defineStore('entry-store', () => {
     }
   }
 
-  return { entryData, registerEntry, saveEntryToStore, deleteEntryData, getEntry }
+  return { entryData, registerEntry, saveEntryToStore, deleteEntryData, getEntry, changeEntry }
 })

--- a/frontend/src/types/entry.ts
+++ b/frontend/src/types/entry.ts
@@ -27,3 +27,9 @@ export interface EntryReturnedByAPI {
   visitDay: Date
   visitTime: string
 }
+
+export interface updatedEntryProperties {
+  isAccompanied: string
+  visitDay: string
+  visitTime: string
+}

--- a/frontend/src/views/EntryChange/EntryChangeForm.vue
+++ b/frontend/src/views/EntryChange/EntryChangeForm.vue
@@ -5,35 +5,25 @@ import CalendarDateField from '@/components/fields/Calendar/CalendarDateField.vu
 import CalendarTimeField from '@/components/fields/Calendar/CalendarTimeField.vue'
 import RouterLinkButton from '@/components/atoms/Button/RouterLinkButton.vue'
 import { useEntryStore } from '@/stores/entryStore'
-// import { ref } from 'vue'
-// import { storeToRefs } from 'pinia'
+import { format, parse } from 'date-fns'
+import { ja } from 'date-fns/locale'
 
-const { entryData, saveEntryData } = useEntryStore()
-
-// const isAccompanied = ref<string>('')
-// const visitDay = ref<string>('')
-// const visitTime = ref<string>('')
-const changedData = {
-  name: entryData.name,
-  gender: entryData.gender,
-  birthday: entryData.birthday,
-  prefecture: entryData.prefecture,
-  tel: entryData.tel,
-  email: entryData.email,
-  isAccompanied: entryData.isAccompanied,
-  visitDay: entryData.visitDay,
-  visitTime: entryData.visitTime,
+const { entryData, saveEntryToStore } = useEntryStore()
+const parsedDate = parse(entryData.visitDay, 'yyyy年M月d日(EEE)', new Date(), { locale: ja })
+const changedEntry = {
+  ...entryData,
+  visitDay: format(parsedDate, 'yyyy-MM-dd'),
 }
 </script>
 
 <template>
   <PageTitle title="日程変更" message="入力内容を変更" />
 
-  <CompanionField v-model="changedData.isAccompanied" />
-  <CalendarDateField v-model="changedData.visitDay" />
-  <CalendarTimeField v-model="changedData.visitTime" />
+  <CompanionField v-model="changedEntry.isAccompanied" />
+  <CalendarDateField v-model="changedEntry.visitDay" />
+  <CalendarTimeField v-model="changedEntry.visitTime" />
 
-  <RouterLinkButton to="/entry/change/confirm" @click-event="saveEntryData(changedData)">
+  <RouterLinkButton to="/entry/change/confirm" @click-event="saveEntryToStore(changedEntry)">
     入力内容確認画面へ
   </RouterLinkButton>
   <RouterLinkButton to="/confirm"> 戻る </RouterLinkButton>

--- a/frontend/src/views/EntryChange/EntryChangeFormConfirmation.vue
+++ b/frontend/src/views/EntryChange/EntryChangeFormConfirmation.vue
@@ -2,14 +2,23 @@
 import ConfirmationContentDisplay from '@/components/ConfirmationContentDisplay.vue';
 import PageTitle from '@/components/PageTitle.vue'
 import RouterLinkButton from '@/components/atoms/Button/RouterLinkButton.vue';
+import { useEntryStore } from '@/stores/entryStore';
 
+const entryStore = useEntryStore()
+const entryData = entryStore.entryData
+const changedProperties = {
+  isAccompanied: entryData.isAccompanied,
+  visitDay: entryData.visitDay,
+  visitTime: entryData.visitTime,
+}
+const changeEntry = entryStore.changeEntry
 </script>
 
 <template>
   <PageTitle title="入力内容確認画面" message="以下の内容で変更しますか？" />
   <ConfirmationContentDisplay />
 
-  <RouterLinkButton to="/entry/change/complete">
+  <RouterLinkButton to="/entry/change/complete" @click-event="changeEntry(12, changedProperties)">
     予約内容を変更する
   </RouterLinkButton>
   <RouterLinkButton to="/entry/change"> 内容を修正する </RouterLinkButton>

--- a/frontend/src/views/EntryChange/EntryConfirmation.vue
+++ b/frontend/src/views/EntryChange/EntryConfirmation.vue
@@ -11,11 +11,27 @@ const { getEntry, saveEntryToStore } = useEntryStore()
 
 onMounted(async () => {
   const registeredEntry = await getEntry(12)
-  const formattedEntry = {
-    ...registeredEntry,
-    birthday: format(registeredEntry.birthday, 'yyyy年M月d日'),
-    isAccompanied: registeredEntry.isAccompanied ? 'あり' : 'なし',
-    visitDay: format(registeredEntry.visitDay, 'yyyy年M月d日(EEE)', { locale: ja }),
+  let formattedEntry = {
+    familyName: '',
+      personalName: '',
+      familyNameKana: '',
+      personalNameKana: '',
+      gender: '',
+      birthday: '',
+      prefecture: '',
+      tel: '',
+      email: '',
+      isAccompanied: '',
+      visitDay: '',
+      visitTime: '',
+  }
+  if (registeredEntry !== null) {
+    formattedEntry = {
+      ...registeredEntry,
+      birthday: format(registeredEntry.birthday, 'yyyy年MM月dd日'),
+      isAccompanied: registeredEntry.isAccompanied ? 'あり' : 'なし',
+      visitDay: format(registeredEntry.visitDay, 'yyyy年MM月dd日(EEE)', { locale: ja }),
+    }
   }
   saveEntryToStore(formattedEntry)
 })


### PR DESCRIPTION
## 概要
- 予約情報1件を更新するAPIをVueに導入

## 背景/経緯
- 予約変更の際、DBを更新するため

## 参考資料

https://github.com/user-attachments/assets/4bc3fcf4-8e09-4d55-86cd-e92584164ea1

