### PR TITLE
Add/introduce delete api into vue

### DIFF
--- a/backend/src/entries/entries.controller.ts
+++ b/backend/src/entries/entries.controller.ts
@@ -29,7 +29,6 @@ export class EntriesController {
 
   @Post()
   async addEntry(@Body() entry: AddEntryDto): Promise<EntryDto> {
-    console.log('届いてる');
     return await this.entriesService.addEntry(entry);
   }
 

--- a/frontend/src/composables/useEntriesAPI.ts
+++ b/frontend/src/composables/useEntriesAPI.ts
@@ -25,7 +25,6 @@ export function useEntriesAPI() {
   }
 
   const useAddEntryAPI = async (entry: Entry) => {
-    // console.log(JSON.stringify(entry))
     const response = await fetch('http://localhost:3000/entries', {
       method: 'POST',
       headers: {
@@ -35,7 +34,6 @@ export function useEntriesAPI() {
     })
 
     if (!response.ok) {
-      // console.log(response)
       throw new EntryAddFailure()
     }
   }

--- a/frontend/src/composables/useEntriesAPI.ts
+++ b/frontend/src/composables/useEntriesAPI.ts
@@ -59,10 +59,26 @@ export function useEntriesAPI() {
       throw new EntryUpdateFailure()
     }
   }
+  class EntryDeleteFailure extends Error {
+    constructor() {
+      super()
+    }
+  }
+
+  const useDeleteEntryAPI = async (id: number) => {
+    const response = await fetch(`http://localhost:3000/entries/${id}`, {
+      method: 'DELETE',
+    })
+
+    if (!response.ok) {
+      throw new EntryDeleteFailure()
+    }
+  }
 
   return {
     useGetEntryAPI,
     useAddEntryAPI,
     useUpdateEntryAPI,
+    useDeleteEntryAPI,
   }
 }

--- a/frontend/src/stores/entryStore.ts
+++ b/frontend/src/stores/entryStore.ts
@@ -63,7 +63,9 @@ export const useEntryStore = defineStore('entry-store', () => {
 
   async function cancelEntry(id: number) {
     try {
-      await useDeleteEntryAPI(id)
+      if ((await useGetEntryAPI(id)) !== null) {
+        await useDeleteEntryAPI(id)
+      }
     } catch (error) {
       if (error) errorMsg.value = 'サーバーエラーによりキャンセルできませんでした'
     }

--- a/frontend/src/stores/entryStore.ts
+++ b/frontend/src/stores/entryStore.ts
@@ -7,6 +7,7 @@ const {
   useGetEntryAPI: useGetEntryAPI,
   useAddEntryAPI: useAddEntryAPI,
   useUpdateEntryAPI: useUpdateEntryAPI,
+  useDeleteEntryAPI: useDeleteEntryAPI,
 } = useEntriesAPI()
 
 export const useEntryStore = defineStore('entry-store', () => {
@@ -60,19 +61,20 @@ export const useEntryStore = defineStore('entry-store', () => {
     entryData.value = entry
   }
 
-  function deleteEntryData() {
-    entryData.value = {
-      name: '',
-      gender: '',
-      birthday: '',
-      prefecture: '',
-      tel: '',
-      email: '',
-      isAccompanied: '',
-      visitDay: '',
-      visitTime: '',
+  async function cancelEntry(id: number) {
+    try {
+      await useDeleteEntryAPI(id)
+    } catch (error) {
+      if (error) errorMsg.value = 'サーバーエラーによりキャンセルできませんでした'
     }
   }
 
-  return { entryData, registerEntry, saveEntryToStore, deleteEntryData, getEntry, changeEntry }
+  return {
+    entryData,
+    registerEntry,
+    saveEntryToStore,
+    getEntry,
+    changeEntry,
+    cancelEntry,
+  }
 })

--- a/frontend/src/views/EntryCancel/EntryCancelConfirmation.vue
+++ b/frontend/src/views/EntryCancel/EntryCancelConfirmation.vue
@@ -7,15 +7,31 @@ import { useEntryStore } from '@/stores/entryStore'
 import { format } from 'date-fns'
 import { ja } from 'date-fns/locale'
 
-const { getEntry, saveEntryToStore, deleteEntryData } = useEntryStore()
+const { getEntry, saveEntryToStore, cancelEntry } = useEntryStore()
 
 onMounted(async () => {
   const registeredEntry = await getEntry(12)
-  const formattedEntry = {
-    ...registeredEntry,
-    birthday: format(registeredEntry.birthday, 'yyyy年M月d日'),
-    isAccompanied: registeredEntry.isAccompanied ? 'あり' : 'なし',
-    visitDay: format(registeredEntry.visitDay, 'yyyy年M月d日(EEE)', { locale: ja }),
+  let formattedEntry = {
+    familyName: '',
+      personalName: '',
+      familyNameKana: '',
+      personalNameKana: '',
+      gender: '',
+      birthday: '',
+      prefecture: '',
+      tel: '',
+      email: '',
+      isAccompanied: '',
+      visitDay: '',
+      visitTime: '',
+  }
+  if (registeredEntry !== null) {
+    formattedEntry = {
+      ...registeredEntry,
+      birthday: format(registeredEntry.birthday, 'yyyy年MM月dd日'),
+      isAccompanied: registeredEntry.isAccompanied ? 'あり' : 'なし',
+      visitDay: format(registeredEntry.visitDay, 'yyyy年MM月dd日(EEE)', { locale: ja }),
+    }
   }
   saveEntryToStore(formattedEntry)
 })
@@ -25,7 +41,7 @@ onMounted(async () => {
   <PageTitle title="予約キャンセル" message="以下の内容をキャンセルしますか？" />
   <ConfirmationContentDisplay />
 
-  <RouterLinkButton to="/entry/cancel/complete" @click-event="deleteEntryData()">
+  <RouterLinkButton to="/entry/cancel/complete" @click-event="cancelEntry(12)">
     予約をキャンセルする
   </RouterLinkButton>
   <RouterLinkButton to=""> 閉じる </RouterLinkButton>

--- a/frontend/src/views/EntryCancel/EntryCancelConfirmation.vue
+++ b/frontend/src/views/EntryCancel/EntryCancelConfirmation.vue
@@ -10,7 +10,7 @@ import { ja } from 'date-fns/locale'
 const { getEntry, saveEntryToStore, cancelEntry } = useEntryStore()
 
 onMounted(async () => {
-  const registeredEntry = await getEntry(12)
+  const registeredEntry = await getEntry(13)
   let formattedEntry = {
     familyName: '',
       personalName: '',
@@ -41,7 +41,7 @@ onMounted(async () => {
   <PageTitle title="予約キャンセル" message="以下の内容をキャンセルしますか？" />
   <ConfirmationContentDisplay />
 
-  <RouterLinkButton to="/entry/cancel/complete" @click-event="cancelEntry(12)">
+  <RouterLinkButton to="/entry/cancel/complete" @click-event="cancelEntry(13)">
     予約をキャンセルする
   </RouterLinkButton>
   <RouterLinkButton to=""> 閉じる </RouterLinkButton>

--- a/frontend/src/views/EntryChange/EntryChangeFormConfirmation.vue
+++ b/frontend/src/views/EntryChange/EntryChangeFormConfirmation.vue
@@ -18,7 +18,7 @@ const changeEntry = entryStore.changeEntry
   <PageTitle title="入力内容確認画面" message="以下の内容で変更しますか？" />
   <ConfirmationContentDisplay />
 
-  <RouterLinkButton to="/entry/change/complete" @click-event="changeEntry(12, changedProperties)">
+  <RouterLinkButton to="/entry/change/complete" @click-event="changeEntry(13, changedProperties)">
     予約内容を変更する
   </RouterLinkButton>
   <RouterLinkButton to="/entry/change"> 内容を修正する </RouterLinkButton>

--- a/frontend/src/views/EntryChange/EntryConfirmation.vue
+++ b/frontend/src/views/EntryChange/EntryConfirmation.vue
@@ -10,7 +10,7 @@ import { ja } from 'date-fns/locale'
 const { getEntry, saveEntryToStore } = useEntryStore()
 
 onMounted(async () => {
-  const registeredEntry = await getEntry(12)
+  const registeredEntry = await getEntry(13)
   let formattedEntry = {
     familyName: '',
       personalName: '',


### PR DESCRIPTION
## 概要
- 予約情報1件を削除するAPIをVueに導入

## 背景/経緯
- 予約キャンセルの際に、DBの予約情報を削除するため

## 参考資料

https://github.com/user-attachments/assets/9e1bc413-ffd4-4247-be87-bb14ee2e7dcb

