### PR TITLE
fix/receive data by Entry from DB

### DIFF
--- a/backend/src/entries/entries.controller.ts
+++ b/backend/src/entries/entries.controller.ts
@@ -11,24 +11,32 @@ import {
   Post,
 } from '@nestjs/common';
 import { EntryDto } from './dto/entry.dto';
-import { AddEntryDto } from './dto/add-entry.dto';
 import { UpdateEntryDto } from './dto/update-entry.dto';
+import { Entry } from '@prisma/client';
 
 @Controller('entries')
 export class EntriesController {
   constructor(private entriesService: EntriesService) {}
 
   @Get(':id')
-  async getEntry(@Param('id', ParseIntPipe) id: number): Promise<EntryDto> {
+  async getEntry(
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<Omit<Entry, 'id' | 'checkInTime'>> {
     const returnedData = await this.entriesService.getEntry(id);
     if (returnedData === null) {
       throw new NotFoundException(`Entry with ID ${id} not found`);
     }
+    console.log(returnedData);
     return returnedData;
   }
 
   @Post()
-  async addEntry(@Body() entry: AddEntryDto): Promise<EntryDto> {
+  async addEntry(
+    @Body() entry: EntryDto,
+  ): Promise<Omit<Entry, 'id' | 'checkInTime'>> {
+    console.log(entry);
+    console.log(typeof entry.visitDay);
+    // entry.visitDay.getDate();
     return await this.entriesService.addEntry(entry);
   }
 

--- a/backend/src/entries/entries.service.ts
+++ b/backend/src/entries/entries.service.ts
@@ -1,15 +1,17 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { EntryDto } from './dto/entry.dto';
-import { AddEntryDto } from './dto/add-entry.dto';
 import { UpdateEntryDto } from './dto/update-entry.dto';
+import { Entry } from '@prisma/client';
 
 @Injectable()
 export class EntriesService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async getEntry(id: number): Promise<EntryDto | null> {
-    return this.prisma.entries.findUnique({
+  async getEntry(
+    id: number,
+  ): Promise<Omit<Entry, 'id' | 'checkInTime'> | null> {
+    return this.prisma.entry.findUnique({
       where: { id },
       select: {
         familyName: true,
@@ -28,7 +30,6 @@ export class EntriesService {
     });
   }
 
-  async addEntry(entry: AddEntryDto): Promise<EntryDto> {
     let isAccompaniedBoolean = true;
     if (entry.isAccompanied === 'なし') {
       isAccompaniedBoolean = false;
@@ -49,14 +50,18 @@ export class EntriesService {
     };
 
     return this.prisma.entries.create({ data });
+  async addEntry(entry: EntryDto): Promise<Omit<Entry, 'id' | 'checkInTime'>> {
   }
 
-  async updateEntry(id: number, entry: UpdateEntryDto): Promise<EntryDto> {
     let isAccompaniedBoolean = true;
     if (entry.isAccompanied === 'なし') {
       isAccompaniedBoolean = false;
     }
     return this.prisma.entries.update({
+  async updateEntry(
+    id: number,
+    entry: UpdateEntryDto,
+  ): Promise<Omit<Entry, 'id' | 'checkInTime'>> {
       where: { id },
       data: {
         isAccompanied: isAccompaniedBoolean,
@@ -66,8 +71,8 @@ export class EntriesService {
     });
   }
 
-  async deleteEntry(id: number): Promise<EntryDto> {
-    return this.prisma.entries.delete({
+  async deleteEntry(id: number): Promise<Omit<Entry, 'id' | 'checkInTime'>> {
+    return this.prisma.entry.delete({
       where: { id },
     });
   }


### PR DESCRIPTION
## 概要
- service, controllerが返す、DBからの取得値の型を、prismaのmodelが提供するEntry型に変更
## 背景/経緯
- 従来DTOを当てていたが、DTOはリクエストの受取が主な役割であり、不適切なため