### PR TITLE
fix/obtain-string-data-only-when-displaying

### DIFF
--- a/backend/src/entries/entries.service.ts
+++ b/backend/src/entries/entries.service.ts
@@ -30,44 +30,17 @@ export class EntriesService {
     });
   }
 
-    let isAccompaniedBoolean = true;
-    if (entry.isAccompanied === 'なし') {
-      isAccompaniedBoolean = false;
-    }
-    const data = {
-      familyName: entry.familyName,
-      personalName: entry.personalName,
-      familyNameKana: entry.familyNameKana,
-      personalNameKana: entry.personalNameKana,
-      gender: entry.gender,
-      birthday: new Date(entry.birthday),
-      prefecture: entry.prefecture,
-      tel: entry.tel,
-      email: entry.email,
-      isAccompanied: isAccompaniedBoolean,
-      visitDay: new Date(entry.visitDay),
-      visitTime: entry.visitTime,
-    };
-
-    return this.prisma.entries.create({ data });
   async addEntry(entry: EntryDto): Promise<Omit<Entry, 'id' | 'checkInTime'>> {
+    return this.prisma.entry.create({ data: entry });
   }
 
-    let isAccompaniedBoolean = true;
-    if (entry.isAccompanied === 'なし') {
-      isAccompaniedBoolean = false;
-    }
-    return this.prisma.entries.update({
   async updateEntry(
     id: number,
     entry: UpdateEntryDto,
   ): Promise<Omit<Entry, 'id' | 'checkInTime'>> {
+    return this.prisma.entry.update({
       where: { id },
-      data: {
-        isAccompanied: isAccompaniedBoolean,
-        visitDay: new Date(entry.visitDay),
-        visitTime: entry.visitTime,
-      },
+      data: entry,
     });
   }
 

--- a/frontend/src/components/ConfirmationContentDisplay.vue
+++ b/frontend/src/components/ConfirmationContentDisplay.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { useEntryStore } from '@/stores/entryStore'
 import { storeToRefs } from 'pinia'
+import { format } from 'date-fns'
+import { ja } from 'date-fns/locale'
 
 const { entryData } = storeToRefs(useEntryStore())
 </script>
@@ -20,7 +22,7 @@ const { entryData } = storeToRefs(useEntryStore())
   </div>
   <div>
     <p>生年月日</p>
-    <p>{{ entryData.birthday }}</p>
+    <p>{{ format(entryData.birthday , 'yyyy年M月d日')}}</p>
   </div>
   <div>
     <p>都道府県</p>
@@ -36,11 +38,11 @@ const { entryData } = storeToRefs(useEntryStore())
   </div>
   <div>
     <p>同伴者</p>
-    <p>{{ entryData.isAccompanied }}</p>
+    <p>{{ entryData.isAccompanied === true ? 'あり' : 'なし' }}</p>
   </div>
   <div>
     <p>来場日</p>
-    <p>{{ entryData.visitDay }}</p>
+    <p>{{ format(entryData.visitDay, 'yyyy年M月d日(EEE)', { locale: ja }) }}</p>
   </div>
   <div>
     <p>来場時間</p>

--- a/frontend/src/composables/useEntriesAPI.ts
+++ b/frontend/src/composables/useEntriesAPI.ts
@@ -16,7 +16,7 @@ export function useEntriesAPI() {
       throw new EntryGetFailure()
     }
 
-    return (await response.json()) as EntryReturnedByAPI
+    return (await response.json()) as Entry
   }
   class EntryAddFailure extends Error {
     constructor() {

--- a/frontend/src/stores/entryStore.ts
+++ b/frontend/src/stores/entryStore.ts
@@ -1,7 +1,8 @@
-import type { Entry, EntryReturnedByAPI, updatedEntryProperties } from '@/types/entry'
+import type { Entry, StringEntry, UpdatedEntryProperties } from '@/types/entry'
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { useEntriesAPI } from '@/composables/useEntriesAPI'
+import { format } from 'date-fns'
 
 const { useGetEntryAPI, useAddEntryAPI, useUpdateEntryAPI, useDeleteEntryAPI } = useEntriesAPI()
 
@@ -12,18 +13,24 @@ export const useEntryStore = defineStore('entry-store', () => {
     familyNameKana: '',
     personalNameKana: '',
     gender: '',
-    birthday: '',
+    birthday: new Date(),
     prefecture: '',
     tel: '',
     email: '',
-    isAccompanied: '',
-    visitDay: '',
+    isAccompanied: true,
+    visitDay: new Date(),
     visitTime: '',
   })
 
   const errorMsg = ref<string>()
 
-  async function getEntry(id: number): Promise<EntryReturnedByAPI | null> {
+  function saveEntryToStore(entry: Entry) {
+    console.log(entry)
+    entryData.value = entry
+    console.log(entryData)
+  }
+
+  async function getEntry(id: number): Promise<Entry | null> {
     try {
       return await useGetEntryAPI(id)
     } catch (error) {
@@ -50,10 +57,6 @@ export const useEntryStore = defineStore('entry-store', () => {
     } catch (error) {
       if (error) errorMsg.value = 'サーバーエラーにより予約できませんでした'
     }
-  }
-
-  function saveEntryToStore(entry: Entry) {
-    entryData.value = entry
   }
 
   async function cancelEntry(id: number) {

--- a/frontend/src/types/entry.ts
+++ b/frontend/src/types/entry.ts
@@ -4,21 +4,6 @@ export interface Entry {
   familyNameKana: string
   personalNameKana: string
   gender: string
-  birthday: string
-  prefecture: string
-  tel: string
-  email: string
-  isAccompanied: string
-  visitDay: string
-  visitTime: string
-}
-
-export interface EntryReturnedByAPI {
-  familyName: string
-  personalName: string
-  familyNameKana: string
-  personalNameKana: string
-  gender: string
   birthday: Date
   prefecture: string
   tel: string
@@ -28,8 +13,15 @@ export interface EntryReturnedByAPI {
   visitTime: string
 }
 
-export interface updatedEntryProperties {
+export type UpdatedEntryProperties = Pick<Entry, 'isAccompanied' | 'visitDay' | 'visitTime'>
+  familyName: string
+  personalName: string
+  familyNameKana: string
+  personalNameKana: string
+  gender: string
+  prefecture: string
+  tel: string
+  email: string
   isAccompanied: string
   visitDay: string
   visitTime: string
-}

--- a/frontend/src/views/EntryCancel/EntryCancelConfirmation.vue
+++ b/frontend/src/views/EntryCancel/EntryCancelConfirmation.vue
@@ -4,36 +4,14 @@ import RouterLinkButton from '@/components/atoms/Button/RouterLinkButton.vue'
 import ConfirmationContentDisplay from '@/components/ConfirmationContentDisplay.vue'
 import { onMounted } from 'vue'
 import { useEntryStore } from '@/stores/entryStore'
-import { format } from 'date-fns'
-import { ja } from 'date-fns/locale'
 
 const { getEntry, saveEntryToStore, cancelEntry } = useEntryStore()
 
 onMounted(async () => {
-  const registeredEntry = await getEntry(13)
-  let formattedEntry = {
-    familyName: '',
-      personalName: '',
-      familyNameKana: '',
-      personalNameKana: '',
-      gender: '',
-      birthday: '',
-      prefecture: '',
-      tel: '',
-      email: '',
-      isAccompanied: '',
-      visitDay: '',
-      visitTime: '',
-  }
+  const registeredEntry = await getEntry(15)
   if (registeredEntry !== null) {
-    formattedEntry = {
-      ...registeredEntry,
-      birthday: format(registeredEntry.birthday, 'yyyy年MM月dd日'),
-      isAccompanied: registeredEntry.isAccompanied ? 'あり' : 'なし',
-      visitDay: format(registeredEntry.visitDay, 'yyyy年MM月dd日(EEE)', { locale: ja }),
-    }
+    saveEntryToStore(registeredEntry)
   }
-  saveEntryToStore(formattedEntry)
 })
 </script>
 

--- a/frontend/src/views/EntryChange/EntryConfirmation.vue
+++ b/frontend/src/views/EntryChange/EntryConfirmation.vue
@@ -4,36 +4,14 @@ import RouterLinkButton from '@/components/atoms/Button/RouterLinkButton.vue'
 import ConfirmationContentDisplay from '@/components/ConfirmationContentDisplay.vue'
 import { onMounted } from 'vue'
 import { useEntryStore } from '@/stores/entryStore'
-import { format } from 'date-fns'
-import { ja } from 'date-fns/locale'
 
 const { getEntry, saveEntryToStore } = useEntryStore()
 
 onMounted(async () => {
-  const registeredEntry = await getEntry(13)
-  let formattedEntry = {
-    familyName: '',
-      personalName: '',
-      familyNameKana: '',
-      personalNameKana: '',
-      gender: '',
-      birthday: '',
-      prefecture: '',
-      tel: '',
-      email: '',
-      isAccompanied: '',
-      visitDay: '',
-      visitTime: '',
-  }
+  const registeredEntry = await getEntry(15)
   if (registeredEntry !== null) {
-    formattedEntry = {
-      ...registeredEntry,
-      birthday: format(registeredEntry.birthday, 'yyyy年MM月dd日'),
-      isAccompanied: registeredEntry.isAccompanied ? 'あり' : 'なし',
-      visitDay: format(registeredEntry.visitDay, 'yyyy年MM月dd日(EEE)', { locale: ja }),
-    }
+    saveEntryToStore(registeredEntry)
   }
-  saveEntryToStore(formattedEntry)
 })
 </script>
 


### PR DESCRIPTION
## 概要
- フロントエンド表示時以外の、データ保持の型を、DBの型に統一
## 背景/経緯
- 型変換が、フロント表示の際のみ一回で済むため