### PR TITLE
add/get_LINE_profile｜LINEプロフィール取得

### DIFF
--- a/backend/src/entries/entries.controller.ts
+++ b/backend/src/entries/entries.controller.ts
@@ -30,18 +30,17 @@ export class EntriesController {
     if (returnedData === null) {
       throw new NotFoundException(`Entry with ID ${id} not found`);
     }
-    console.log(returnedData);
     return returnedData;
   }
 
   @Post()
   async addEntry(
-    @Body() entry: EntryDto,
+    @Body('entry') entry: EntryDto,
+    @Body('idToken') idToken: string,
+    @Body('clientId') clientId: string,
   ): Promise<Omit<Entry, 'id' | 'checkInTime'>> {
-    console.log(entry);
-    console.log(typeof entry.visitDay);
-    // entry.visitDay.getDate();
-    // lineService.sendEntryCompletionMessage(userID, entry);
+    const userId = await this.lineService.getUserId(idToken, clientId);
+    await this.lineService.sendEntryCompletionMessage(userId, entry);
     return await this.entriesService.addEntry(entry);
   }
 

--- a/backend/src/line/line.service.ts
+++ b/backend/src/line/line.service.ts
@@ -15,7 +15,10 @@ const client = new MessagingApiClient({
 
 @Injectable()
 export class LineService {
-  async getUserId(idToken: string, clientId: string): Promise<string> {
+  async getProfile(
+    idToken: string,
+    clientId: string,
+  ): Promise<IdTokenVerifiedResponse | IdTokenVerifiedError> {
     const response = await fetch('https://api.line.me/oauth2/v2.1/verify', {
       method: 'POST',
       headers: {
@@ -27,15 +30,9 @@ export class LineService {
       }),
     });
 
-    const data = (await response.json()) as
+    return (await response.json()) as
       | IdTokenVerifiedResponse
       | IdTokenVerifiedError;
-
-    if ('sub' in data) {
-      return data.sub;
-    } else {
-      return data.error_description;
-    }
   }
 
   async sendEntryCompletionMessage(userId: string, entry: EntryDto) {

--- a/backend/src/line/types/IdTokenVerifiedError.ts
+++ b/backend/src/line/types/IdTokenVerifiedError.ts
@@ -1,0 +1,4 @@
+export interface IdTokenVerifiedError {
+  error: string;
+  error_description: string;
+}

--- a/backend/src/line/types/IdTokenVerifiedResponse.ts
+++ b/backend/src/line/types/IdTokenVerifiedResponse.ts
@@ -1,0 +1,12 @@
+export interface IdTokenVerifiedResponse {
+  iss: string;
+  sub: string;
+  aud: string;
+  exp: number;
+  iat: number;
+  nonce: string;
+  amr: string[];
+  name: string;
+  picture: string;
+  email: string;
+}


### PR DESCRIPTION
## 対応内容
 - LINEプロフィールを取得するメソッドを作成し、コントローラーで使用
   - プッシュメッセージ送信のために、LINEプロフィールに含まれるuserIDが必要なため
## 対象課題
 - [[LINE Messaging API] LINEプロフィール情報取得メソッド](https://snsnap.backlog.jp/view/WECALL_GENERALIZED-867)
## 確認内容
 - [APIをフロントエンドに繋いだタイミング](https://github.com/wannabehime/training_simplified_wecall/pull/33)で動作確認し、下記の通りメッセージが送信されることを確認

https://github.com/user-attachments/assets/3ec3bd79-0c90-4f09-b040-1c3508d9030d


## 懸念点
 - なし
## 残対応
 - なし