### PR TITLE
Add/send id token to backend｜チャネルIDとIDトークンをバックエンドに送信

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,11 +1,30 @@
 <script setup lang="ts">
-import { RouterLink, RouterView } from 'vue-router'
+import { RouterView } from 'vue-router'
+import { onMounted } from 'vue'
+import liff from '@line/liff'
+import router from './router'
+import { useLineStore } from './stores/lineStore'
+import { storeToRefs } from 'pinia'
+
+const liffId = import.meta.env.VITE_LIFF_ID as string
+const { idToken: idTokenRef } = storeToRefs(useLineStore())
+
+onMounted(async () =>{
+  await liff.init({ liffId: liffId, withLoginOnExternalBrowser: true })
+
+  if (router.currentRoute.value.path === '/') {
+    router.push('/entry')
+  }
+
+  const idToken = liff.getIDToken()
+  if (idToken !== null) {
+    idTokenRef.value = idToken
+  }
+})
 </script>
 
 <template>
   <RouterView />
 </template>
 
-<style scoped>
-
-</style>
+<style scoped></style>

--- a/frontend/src/composables/useEntriesAPI.ts
+++ b/frontend/src/composables/useEntriesAPI.ts
@@ -24,15 +24,13 @@ export function useEntriesAPI() {
     }
   }
 
-  const useAddEntryAPI = async (entry: Entry) => {
-    console.log(entry)
-    console.log(JSON.stringify(entry, null, 2))
+  const useAddEntryAPI = async (entry: Entry, idToken: string, clientId: string) => {
     const response = await fetch('/api/entries', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify(entry),
+      body: JSON.stringify({ entry, idToken, clientId }),
     })
 
     if (!response.ok) {
@@ -47,7 +45,6 @@ export function useEntriesAPI() {
   }
 
   const useUpdateEntryAPI = async (id: number, properties: UpdatedEntryProperties) => {
-    console.log(properties)
     const response = await fetch(`/api/entries/${id}`, {
       method: 'PATCH',
       headers: {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,21 +1,12 @@
 import './assets/main.css'
-import liff from '@line/liff'
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 
 import App from './App.vue'
 import router from './router'
 
-const liffId = import.meta.env.VITE_LIFF_ID as string
-
 const app = createApp(App)
 app.use(createPinia())
 app.use(router)
-
-await liff.init({ liffId: liffId, withLoginOnExternalBrowser: true }).then(() => {
-  if (router.currentRoute.value.path === '/') {
-    router.push('/entry')
-  }
-})
 
 app.mount('#app')

--- a/frontend/src/stores/entryStore.ts
+++ b/frontend/src/stores/entryStore.ts
@@ -76,9 +76,9 @@ export const useEntryStore = defineStore('entry-store', () => {
     }
   }
 
-  async function registerEntry(submittedEntry: Entry) {
+  async function registerEntry(submittedEntry: Entry, idToken: string, clientId: string) {
     try {
-      await useAddEntryAPI(submittedEntry)
+      await useAddEntryAPI(submittedEntry, idToken, clientId)
     } catch (error) {
       if (error) errorMsg.value = 'サーバーエラーにより予約できませんでした'
     }

--- a/frontend/src/stores/lineStore.ts
+++ b/frontend/src/stores/lineStore.ts
@@ -1,0 +1,12 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const useLineStore = defineStore('line-store', () => {
+  const idToken = ref<string>('')
+  const clientId = import.meta.env.VITE_LINE_CLIENT_ID as string
+
+  return {
+    idToken,
+    clientId,
+  }
+})

--- a/frontend/src/views/Entry/EntryFormConfirmation.vue
+++ b/frontend/src/views/Entry/EntryFormConfirmation.vue
@@ -3,15 +3,17 @@ import ConfirmationContentDisplay from '@/components/ConfirmationContentDisplay.
 import PageTitle from '@/components/PageTitle.vue'
 import RouterLinkButton from '@/components/atoms/Button/RouterLinkButton.vue'
 import { useEntryStore } from '@/stores/entryStore'
+import { useLineStore } from '@/stores/lineStore'
 
 const { entryData, registerEntry } = useEntryStore()
+const { idToken, clientId } = useLineStore()
 </script>
 
 <template>
   <PageTitle title="入力内容確認画面" message="以下の内容で予約しますか？" />
   <ConfirmationContentDisplay />
 
-  <RouterLinkButton to="/entry/complete" @click-event="registerEntry(entryData)">
+  <RouterLinkButton to="/entry/complete" @click-event="registerEntry(entryData, idToken, clientId)">
     予約する
   </RouterLinkButton>
   <RouterLinkButton to="/entry"> 内容を修正する </RouterLinkButton>


### PR DESCRIPTION
## 対応内容
 - LINEプロフィール取得に必要な、チャネルIDとIDトークンをバックエンドに送信
   - liff.initを、main.tsからApp.vueに移行
     - liff.getIDTokenで取得したIDトークンを、storeから呼び出した変数に格納したい
     - →storeはvueで呼び出す必要 + liff.getIDTokenの使用にはliff.initが必要
     - →liff.getIDToken + liff.initをApp.vueに移行
## 対象課題
 - [[LINE Messaging API] 取得したID tokenを各種メソッドで使用（予約完了・変更・キャンセル）](https://snsnap.backlog.jp/view/WECALL_GENERALIZED-868)
## 確認内容
 - 下記の通り、メッセージが送信されることを確認

https://github.com/user-attachments/assets/fba5be93-0e33-4217-9fd7-964b80640c99

## 懸念点
 - なし
## 残対応
 - なし